### PR TITLE
ENH: Added support for windows (convert sys calls to shelljs calls)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "start": "electron .",
-    "postinstall": "rm -rf web && mkdir -p web && cp -r ../dist web/www && cp -r ../server web/server",
+    "postinstall": "node postinstall.js",
     "build:all": "electron-packager . --all --icon ./icon.icns --out ./bin/ --overwrite",
     "build:mac": "electron-packager . --darwin --icon ./icon.icns --out ./bin/ --overwrite",
     "build:win": "electron-packager . --win32 --out ./bin/ --overwrite",

--- a/electron/postinstall.js
+++ b/electron/postinstall.js
@@ -1,0 +1,8 @@
+var sh=require('shelljs');
+
+sh.rm('-rf', 'web');
+sh.mkdir('web');
+sh.mkdir('web/www');
+sh.cp('-rf', '../dist/*', 'web/www');
+sh.mkdir('web/server');
+sh.cp('-rf', '../server/*', 'web/server');


### PR DESCRIPTION
The postinstall command in the package.json file for electron called unix commands.   This would result
in errors being reported when run on Windows.

In this commit, those calls have been converted to use shelljs in a postinstall.js file.