### PR TITLE
ENH: Add support for Python3 (package StringIO -> io)

### DIFF
--- a/server/tubeutils.py
+++ b/server/tubeutils.py
@@ -1,4 +1,8 @@
-from StringIO import StringIO
+import sys
+if sys.version_info >= (3, 0):
+  from io import StringIO
+else:
+  from StringIO import StringIO
 
 import itk
 


### PR DESCRIPTION
In Python3, StringIO is in the package io.