### PR TITLE
ENH: Bump version of electron to avoid security warning

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -5,10 +5,10 @@
   "version": "0.0.1",
   "main": "index.js",
   "dependencies": {
-    "electron": "1.7.9",
+    "about-window": "1.4.0",
+    "electron": "^1.7.11",
     "electron-settings": "3.1.2",
-    "get-port": "3.2.0",
-    "about-window": "1.4.0"
+    "get-port": "3.2.0"
   },
   "devDependencies": {
     "electron-packager": "8.1.0"


### PR DESCRIPTION
electron has a known critical severity security vulnerability
in version range >= 1.7.0,< 1.7.11.  Jumping to ^1.7.11